### PR TITLE
Conforming to Julia Package template

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,31 @@
+# Documentation: https://github.com/JuliaCI/Appveyor.jl
+environment:
+  matrix:
+  - julia_version: 1.3
+  - julia_version: nightly
+platform:
+  - x86
+  - x64
+matrix:
+  allow_failures:
+    - julia_version: nightly
+branches:
+  only:
+    - master
+    - /release-.*/
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+on_success:
+  - echo "%JL_CODECOV_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,14 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+task:
+  name: FreeBSD
+  env:
+    JULIA_VERSION: 1.3
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+  coverage_script:
+    - cirrusjl coverage codecov coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.jl.*.cov
+*.jl.cov
+*.jl.mem
+.DS_Store
+/Manifest.toml
+/dev/
+/docs/build/
+/docs/site/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - 1.3
+  - nightly
+notifications:
+  email: false
+after_success:
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
+  include:
+    - stage: Documentation
+      julia: 1.3
+      script: julia --project=docs -e '
+          using Pkg;
+          Pkg.develop(PackageSpec(path=pwd()));
+          Pkg.instantiate();
+          include("docs/make.jl");'
+      after_success: skip

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Sen Research Group, Saunak Sen, Hyeonju Kim, Gregory Farage, Chelsea Trotter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "DiseaseOutbreak"
+uuid = "fc7a96c5-dcbb-4e67-88f4-ac6715a4c4cc"
+authors = ["Sen Research Group", "Saunak Sen", "Hyeonju Kim", "Gregory Farage", "Chelsea Trotter"]
+version = "0.1.0"
+
+[compat]
+julia = "1.3"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# DiseaseOutbreak
+
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://chelseatrotter.github.io/DiseaseOutbreak.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://chelseatrotter.github.io/DiseaseOutbreak.jl/dev)
+[![Build Status](https://travis-ci.com/chelseatrotter/DiseaseOutbreak.jl.svg?branch=master)](https://travis-ci.com/chelseatrotter/DiseaseOutbreak.jl)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/chelseatrotter/DiseaseOutbreak.jl?svg=true)](https://ci.appveyor.com/project/chelseatrotter/DiseaseOutbreak-jl)
+[![Codecov](https://codecov.io/gh/chelseatrotter/DiseaseOutbreak.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/chelseatrotter/DiseaseOutbreak.jl)
+[![Coveralls](https://coveralls.io/repos/github/chelseatrotter/DiseaseOutbreak.jl/badge.svg?branch=master)](https://coveralls.io/github/chelseatrotter/DiseaseOutbreak.jl?branch=master)
+[![Build Status](https://api.cirrus-ci.com/github/chelseatrotter/DiseaseOutbreak.jl.svg)](https://cirrus-ci.com/github/chelseatrotter/DiseaseOutbreak.jl)

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,92 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.1"
+
+[[Documenter]]
+deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "bc99c157ff2957c058a1067061d16c2c83d1ec42"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.24.9"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.1"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,17 @@
+using Documenter, DiseaseOutbreak
+
+makedocs(;
+    modules=[DiseaseOutbreak],
+    format=Documenter.HTML(),
+    pages=[
+        "Home" => "index.md",
+    ],
+    repo="https://github.com/chelseatrotter/DiseaseOutbreak.jl/blob/{commit}{path}#L{line}",
+    sitename="DiseaseOutbreak.jl",
+    authors="Sen Research Group, Saunak Sen, Hyeonju Kim, Gregory Farage, Chelsea Trotter",
+    assets=String[],
+)
+
+deploydocs(;
+    repo="github.com/chelseatrotter/DiseaseOutbreak.jl",
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,8 @@
+# DiseaseOutbreak.jl
+
+```@index
+```
+
+```@autodocs
+Modules = [DiseaseOutbreak]
+```

--- a/src/DiseaseOutbreak.jl
+++ b/src/DiseaseOutbreak.jl
@@ -1,0 +1,5 @@
+module DiseaseOutbreak
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,6 @@
+using DiseaseOutbreak
+using Test
+
+@testset "DiseaseOutbreak.jl" begin
+    # Write your own tests here.
+end


### PR DESCRIPTION
This pull request adds Julia Package conventional structure to your project. 

Specifically, it uses PkgTemplate.jl to generate the package structure: Documenter, CI, Project.toml, Manifest.toml as well as some miscellaneous things in .gitignore. 

I have not moved your code to appropriate location.  This is to create the least amount of conflicts and have a easy merge. Once you accept this pull request, the structure has been established, I will move some code to the designated place, such as test.jl in /test folder.   